### PR TITLE
Tsubaki/update ci

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,26 +1,28 @@
 name: Docker Image CI
-
 on:
   push:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-
 jobs:
   build:
     runs-on: macos-latest
-
     steps:
-    - uses: actions/checkout@v4
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - name: Build Docker image for Apple Silicon
-      run: |
-        docker buildx build \
-          --platform linux/arm64 \
-          --file Dockerfile \
-          --tag my-image-name:$(date +%s) \
-          --load \
-          .
+      - uses: actions/checkout@v4
+      
+      - name: Set up Docker environment
+        run: |
+          brew install colima docker
+          colima start --cpu 2 --memory 4 --disk 10
+          echo "DOCKER_HOST=unix://${HOME}/.colima/default/docker.sock" >> $GITHUB_ENV
+          
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        
+      - name: Build Docker image for Apple Silicon
+        run: |
+          docker buildx build \
+            --platform linux/arm64 \
+            --file Dockerfile \
+            --tag my-image-name:$(date +%s) \
+            --load

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,12 +9,27 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Set up Docker environment
         run: |
-          brew install colima docker
-          colima start --cpu 2 --memory 4 --disk 10
-          echo "DOCKER_HOST=unix://${HOME}/.colima/default/docker.sock" >> $GITHUB_ENV
+          brew install --cask docker
+          open -a Docker
+
+          echo "Waiting for Docker to start..."
+          timeout=60
+          until docker info > /dev/null 2>&1 || [ $timeout -le 0 ]; do
+            sleep 1
+            ((timeout--))
+            if [ $((timeout % 10)) -eq 0 ]; then
+              echo "Still waiting for Docker... $timeout seconds remaining"
+            fi
+          done
+          if [ $timeout -le 0 ]; then
+            echo "Docker failed to start within timeout"
+            exit 1
+          fi
+          echo "Docker started successfully"
+          docker info
           
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,25 +9,31 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-
+      
       - name: Set up Docker environment
         run: |
           brew install --cask docker
-          open -a Docker
-
+          ls -la /Applications/
+          open /Applications/Docker.app
+          docker version || true
+          
           echo "Waiting for Docker to start..."
-          timeout=60
+          timeout=120 
           until docker info > /dev/null 2>&1 || [ $timeout -le 0 ]; do
-            sleep 1
-            ((timeout--))
+            sleep 2
+            ((timeout-=2))
             if [ $((timeout % 10)) -eq 0 ]; then
               echo "Still waiting for Docker... $timeout seconds remaining"
+
+              ps aux | grep -i docker || true
             fi
           done
+          
           if [ $timeout -le 0 ]; then
             echo "Docker failed to start within timeout"
             exit 1
           fi
+          
           echo "Docker started successfully"
           docker info
           

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up Docker
+        run: |
+          brew install docker
+          brew install colima
+          colima start
+
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,11 +37,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up Docker
+      - name: Set up Docker environment
         run: |
-          brew install docker
-          brew install colima
-          colima start
+          brew install --cask docker
+          open -a Docker
+
+          echo "Waiting for Docker to start..."
+          timeout=60
+          until docker info > /dev/null 2>&1 || [ $timeout -le 0 ]; do
+            sleep 1
+            ((timeout--))
+            if [ $((timeout % 10)) -eq 0 ]; then
+              echo "Still waiting for Docker... $timeout seconds remaining"
+            fi
+          done
+          if [ $timeout -le 0 ]; then
+            echo "Docker failed to start within timeout"
+            exit 1
+          fi
+          echo "Docker started successfully"
+          docker info
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer


### PR DESCRIPTION
I try to update [docker-image.yml](https://github.com/ankorom0tim0ti/ROS-Noetic-Apple-Silicon/compare/main...Michi-Tsubaki:ROS-Noetic-Apple-Silicon:tsubaki/update_ci?expand=1#diff-dbade1e5797a7633e024a7685a43a7cbd96ae6fefc6314294807ae34cd83712c) and [docker-publish.yml](https://github.com/ankorom0tim0ti/ROS-Noetic-Apple-Silicon/compare/main...Michi-Tsubaki:ROS-Noetic-Apple-Silicon:tsubaki/update_ci?expand=1#diff-5b21991be47c2922383bdc0b6bf00b65af7db51b82d049dd8d6ad03e3d37ac98) to pass CI.

I am not sure wheter it will succeed or not...

I suspect that the main cause of the failure is "docker desktop for mac" is not free, so, I refer to the following website
https://qiita.com/muramasa2/items/02bdf7dddd160c8f1d8a
and try to fix the error.